### PR TITLE
chore: jms config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,7 @@ DB_HOST='beer-order-database'
 DB_HOST_PORT=3308
 
 EXECUTE_INITIAL_JOB=true
+
+# jms
+JMS_USER='jms_user'
+JMS_PASSWORD='jms_secret'

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.egon</groupId>
 		<artifactId>mssc-brewery-bom</artifactId>
-		<version>1.1.0</version>
+		<version>1.2.0</version>
 	</parent>
 	<groupId>com.egon</groupId>
 	<artifactId>mssc-beer-order-service</artifactId>

--- a/src/main/java/com/egon/msscbeerorderservice/config/JmsConfig.java
+++ b/src/main/java/com/egon/msscbeerorderservice/config/JmsConfig.java
@@ -1,0 +1,39 @@
+package com.egon.msscbeerorderservice.config;
+
+import jakarta.jms.ConnectionFactory;
+import org.springframework.boot.autoconfigure.jms.DefaultJmsListenerContainerFactoryConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jms.annotation.EnableJms;
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+import org.springframework.jms.config.JmsListenerContainerFactory;
+import org.springframework.jms.support.converter.MappingJackson2MessageConverter;
+import org.springframework.jms.support.converter.MessageConverter;
+import org.springframework.jms.support.converter.MessageType;
+
+/**
+ * <a href="https://spring.io/guides/gs/messaging-jms">Spring Messaging JMS guide</a>
+ */
+@EnableJms
+@Configuration
+public class JmsConfig {
+
+  public static final String QUEUE_ORDER_SERVICE = "queue_order_service";
+
+  @Bean
+  public JmsListenerContainerFactory<?> myFactory(
+      ConnectionFactory connectionFactory,
+      DefaultJmsListenerContainerFactoryConfigurer configurer) {
+    DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
+    configurer.configure(factory, connectionFactory);
+    return factory;
+  }
+
+  @Bean // Serialize message content to json using TextMessage
+  public MessageConverter jacksonJmsMessageConverter() {
+    MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+    converter.setTargetType(MessageType.TEXT);
+    converter.setTypeIdPropertyName("_type");
+    return converter;
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,5 +20,10 @@ logging.level.org.hibernate.orm.jdbc.bind=TRACE
 # log web, jpa transactions, etc
 # logging.level.org.springframework=trace
 
+# jms
+spring.artemis.user=${JMS_USER}
+spring.artemis.password=${JMS_PASSWORD}
+
+# app
 beer.service.host=http://localhost:8080
 beer.initial.job.execute=${EXECUTE_INITIAL_JOB}


### PR DESCRIPTION
You can use the ActiveMQ Artemis from [this repo](https://github.com/egon89/docker-mono-repo/tree/main/activemq-artemis).
ActiveMQ Web Console: http://localhost:8161

We need of the **spring-boot-starter-artemis** dependency. It was included in [POM parent](https://github.com/egon89/mssc-brewery-bom/commit/10d1f164c74ef89b6af05c9caf5fd91df8f72098).

:grey_exclamation: When the listener throws an exception, the message will be send to DLQ.